### PR TITLE
Match the dht api

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -32,6 +32,8 @@ class Node extends EventEmitter {
       .on('error', this._onError)
       .on('close', this._onClose)
 
+    this.destroyed = false
+    
     this._protocol
       .on('connection', this._onConnection)
       .on('destroy', this._onDestroy)
@@ -74,7 +76,7 @@ class Node extends EventEmitter {
       options = {}
     }
 
-    const server = new Server(this._socket, this._protocol, options)
+    const server = new Server(this, options)
     this._servers.add(server)
 
     server.once('close', () => this._servers.delete(server))
@@ -117,8 +119,15 @@ class Node extends EventEmitter {
     return query.finished()
   }
 
-  async destroy () {
+  async destroy ({ force } = {}) {
+    if (this.destroyed) return
+    if (!force) {
+      const closing = []
+      for (const server of this._servers) closing.push(server.close())
+      await Promise.allSettled(closing)
+    }
     await this._socket.destroy()
+    this.destroyed = true
   }
 
   static fromTransport ({ Socket }, socket, opts) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -10,13 +10,13 @@ const m = require('./messages')
 const crypto = require('./crypto')
 
 class Node extends EventEmitter {
-  constructor (socket, protocol) {
+  constructor (socket, protocol, options = {}) {
     super()
 
     this._socket = socket
     this._protocol = protocol || new Protocol(socket)
 
-    this.defaultKeyPair = crypto.keyPair()
+    this.defaultKeyPair = options.keyPair || crypto.keyPair()
 
     this._servers = new Set()
     this._queries = new Set()
@@ -121,8 +121,8 @@ class Node extends EventEmitter {
     await this._socket.destroy()
   }
 
-  static fromTransport ({ Socket }, socket) {
-    return new Node(new Socket(socket))
+  static fromTransport ({ Socket }, socket, opts) {
+    return new Node(new Socket(socket), null, opts)
   }
 
   static keyPair (seed) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -33,7 +33,7 @@ class Node extends EventEmitter {
       .on('close', this._onClose)
 
     this.destroyed = false
-    
+
     this._protocol
       .on('connection', this._onConnection)
       .on('destroy', this._onDestroy)

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,14 +8,14 @@ const { SocketSet } = require('./socket-set')
 const crypto = require('./crypto')
 
 class Server extends EventEmitter {
-  constructor (socket, protocol, options = {}) {
+  constructor (dht, options = {}) {
     super()
 
-    this._socket = socket
-    this._protocol = protocol || new Protocol(socket)
+    this.dht = dht
+    this._socket = dht._socket
+    this._protocol = dht._protocol || new Protocol(dht._socket)
     this._firewall = options.firewall || allowAll
 
-    this._keyPair = null
     this._connections = new SocketSet()
     this._address = null
     this._listening = null
@@ -25,6 +25,8 @@ class Server extends EventEmitter {
     this._onConnection = onConnection.bind(this)
     this._onDestroy = onDestroy.bind(this)
     this._onData = onData.bind(this)
+
+    this.closed = false
 
     this._socket
       .on('close', this._onClose)
@@ -44,10 +46,10 @@ class Server extends EventEmitter {
     return this._keyPair && this._keyPair.publicKey
   }
 
-  async listen (keyPair) {
+  async listen (keyPair = this.dht.defaultKeyPair) {
     if (this._listening) return this._listening
 
-    this._keyPair = keyPair || crypto.keyPair()
+    this._keyPair = keyPair 
 
     await this._protocol.listen(this._keyPair)
 
@@ -84,6 +86,7 @@ class Server extends EventEmitter {
         if (buffer.equals(message.publicKey, this._keyPair.publicKey)) {
           this._protocol.off('close', onClosed)
           this.emit('close')
+          this.closed = true
           resolve()
         }
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,8 +5,6 @@ const { Protocol } = require('./protocol')
 const { Socket } = require('./socket')
 const { SocketSet } = require('./socket-set')
 
-const crypto = require('./crypto')
-
 class Server extends EventEmitter {
   constructor (dht, options = {}) {
     super()
@@ -49,7 +47,7 @@ class Server extends EventEmitter {
   async listen (keyPair = this.dht.defaultKeyPair) {
     if (this._listening) return this._listening
 
-    this._keyPair = keyPair 
+    this._keyPair = keyPair
 
     await this._protocol.listen(this._keyPair)
 
@@ -85,8 +83,8 @@ class Server extends EventEmitter {
       const onClosed = (message) => {
         if (buffer.equals(message.publicKey, this._keyPair.publicKey)) {
           this._protocol.off('close', onClosed)
-          this.emit('close')
           this.closed = true
+          this.emit('close')
           resolve()
         }
       }


### PR DESCRIPTION
Added the following:
- `this.destroyed`
- `destroy({force})`
- `server.dht`, to listen on the `this.dht.defaultKeyPair`
- `server.closed`

Things I couldn't add:
- createServer() firewall feature.
- Catching the error on `node.ready()` when the relay URL is invalid

API not yet tested from the `dht` README.md:
- https://github.com/hyperswarm/dht#additional-peer-discovery
- https://github.com/hyperswarm/dht#mutableimmutable-records 
- Anything API in the `dht-rpc` but not in the `dht` README.md